### PR TITLE
Add CollectAssertions method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ public class MyClass
 }
 ```
 
-
 Add package:
 
 ```bash
@@ -49,6 +48,7 @@ public void TestMyClass()
         MyInt = i => Assert.Equal(5, i),        
         MyString = s => Assert.Equal("Hello", s),
         MyBool = b => Assert.Equal(true, b),
+        IgnoredProperty = ObjectAssertionsHelpers.Ignore<Foo>("Not in test scope"")
     };
 
     assertions.Assert();

--- a/samples/ObjectAssertions.Sample/Program.cs
+++ b/samples/ObjectAssertions.Sample/Program.cs
@@ -52,7 +52,7 @@ namespace ObjectAssertions.Sample
                 StringValue = s => Assert.Equal("Hello world", s),
                 NestedObjectValue = n => new NestedObjectAssertions(n)
                 {
-                    NestedInt = ni => Assert.True(ni > 0),
+                    NestedInt = ObjectAssertionsHelpers.Ignore<int>("Out of test scope"),
                     NestedString = ns => Assert.Equal("ubuaa", ns)
                 }.Assert()
             };

--- a/src/ObjectAssertions.Abstractions/IAssertsAllPropertiesOf.cs
+++ b/src/ObjectAssertions.Abstractions/IAssertsAllPropertiesOf.cs
@@ -1,4 +1,6 @@
-﻿namespace ObjectAssertions.Abstractions
+﻿using System;
+
+namespace ObjectAssertions.Abstractions
 {
     /// <summary>
     /// This is marker interface used to designate type for which assertions will be generated.

--- a/src/ObjectAssertions.Abstractions/ObjectAssertionsHelpers.cs
+++ b/src/ObjectAssertions.Abstractions/ObjectAssertionsHelpers.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace ObjectAssertions.Abstractions
+{
+    /// <summary>
+    /// Contains helper classes designed to be used with assertion
+    /// </summary>
+    public class ObjectAssertionsHelpers
+    {
+        /// <summary>
+        /// Ignores assertion. Can be used in object initializer of class implementing <see cref="IAssertsAllPropertiesOf{TObject}"/> interface.
+        /// This method does nothing.
+        /// </summary>
+        /// <typeparam name="T">Type of property which is ignored</typeparam>
+        /// <param name="reason">Explains why property check was ignored</param>
+        /// <returns>Noop delegate</returns>
+        public static Action<T> Ignore<T>(string reason)
+        {
+            return t => { };
+        }
+    }
+}

--- a/src/ObjectAssertions/Generator/ClassGenerator.cs
+++ b/src/ObjectAssertions/Generator/ClassGenerator.cs
@@ -61,6 +61,7 @@ namespace ObjectAssertions.Generator
                                     .AddMembers(constructor)
                                     .AddMembers(GenerateFields())
                                     .AddMembers(GenerateAssertMethod())
+                                    .AddMembers(GenerateCollectAssertionsMethod())
                 ;
 
                 classDeclaration = classDeclaration.NormalizeWhitespace();
@@ -91,6 +92,12 @@ namespace ObjectAssertions.Generator
         private MethodDeclarationSyntax GenerateAssertMethod()
         {
             return MemberGenerator.GenerateAssertMethod(_semanticModel, "Assert", _configuration.AssertionFieldName, _configuration.Members.Select(n => n.Name));
+        }
+
+        private MethodDeclarationSyntax GenerateCollectAssertionsMethod()
+        {
+            return MemberGenerator.GenerateCollectAssertionsMethod(_semanticModel, "CollectAssertions", _configuration.AssertionFieldName, _configuration.Members.Select(n => n.Name).ToList());
+
         }
 
         private void GenerateNamespace(IndentedTextWriter sourceWriter)


### PR DESCRIPTION
This method will return array of all generated assertions. May be used to interface with libaries like Shouldy, which do not support assertions scopes